### PR TITLE
Used NewService function instead of deprecated function New for getting Calendar Service

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/option"
 )
 
 // Create a post as google calendar bot to the user directly
@@ -71,9 +72,8 @@ func (p *Plugin) getCalendarService(userID string) (*calendar.Service, error) {
 	config := p.CalendarConfig()
 	ctx := context.Background()
 	tokenSource := config.TokenSource(ctx, &token)
-	client := oauth2.NewClient(ctx, tokenSource)
 
-	srv, err := calendar.New(client)
+	srv, err := calendar.NewService(ctx, option.WithTokenSource(tokenSource))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The [`New` function](https://godoc.org/google.golang.org/api/calendar/v3#New) for getting the Calendar service is deprecated. 
This PR replaces it with the [`NewService` function](https://godoc.org/google.golang.org/api/calendar/v3#NewService). 
The parameters to `NewService` make use of [`WithTokenSource` function](https://godoc.org/google.golang.org/api/option#WithTokenSource) from https://godoc.org/google.golang.org/api/option.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes https://github.com/mattermost/mattermost-plugin-google-calendar/issues/19
