### PR TITLE
golang-cli-lint error fixed during automake operation: server/plugin.…

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -13,16 +13,16 @@ import (
 
 // Plugin implements the interface expected by the Mattermost server to communicate between the server and plugin processes.
 type Plugin struct {
-	plugin.MattermostPlugin
-
-	// configurationLock synchronizes access to the configuration.
-	configurationLock sync.RWMutex
-
 	// configuration is the active plugin configuration. Consult getConfiguration and
 	// setConfiguration for usage.
 	configuration *configuration
 
+	plugin.MattermostPlugin
+
 	botID string
+
+	// configurationLock synchronizes access to the configuration.
+	configurationLock sync.RWMutex
 }
 
 //OnActivate function ensures what bot does when become actived


### PR DESCRIPTION
…go:15:13: fieldalignment: struct with 72 pointer bytes could be 48 (govet)

This error arises in  golangci-lint during run `make`.

The reason of this bug - bad maligned struct.
I used this article [https://medium.com/@sebassegros/golang-dealing-with-maligned-structs-9b77bacf4b97]
to make compact alignment in `type Plugin struct`

After this change my plugin was built correctly.
