### PR TITLE
[MM-55526] Fix slash command failure when issued from Calls thread

### DIFF
--- a/webapp/src/plugin_hooks.ts
+++ b/webapp/src/plugin_hooks.ts
@@ -31,7 +31,7 @@ export default class Hooks {
         }
 
         const providerConfiguration = getProviderConfiguration(this.store.getState());
-        if (message.startsWith(`/${providerConfiguration.CommandTrigger} ` + createEventCommand)) {
+        if (providerConfiguration && message.startsWith(`/${providerConfiguration.CommandTrigger} ` + createEventCommand)) {
             return this.handleCreateEventSlashCommand(message, contextArgs);
         }
 


### PR DESCRIPTION
#### Summary

Some slash commands are not working when issued from the Calls chat thread (in the pop out window). I thought it was a Calls issue but locally it didn't happen so I debugged a bit on Community and the exception is actually coming from this plugin (see screenshot). The returned `providerConfiguration` can be `null` which will cause an exception and break the whole chain of slash handlers.

![image](https://github.com/mattermost/mattermost-plugin-google-calendar/assets/1832946/aed20405-104f-47f1-a74e-2483ec4bde2d)


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-55526
