### PR TITLE
deps: upgrade golangci-lint to v1.55.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,5 @@ jobs:
   plugin-ci:
     uses: mattermost/actions-workflows/.github/workflows/plugin-ci.yml@main
     secrets: inherit
+    with:
+      golangci-lint-version: "v1.55.2"


### PR DESCRIPTION
#### Summary

Upgrades the golangci-lint version to 1.55.2 to avoid lint failures in the CI
