### PR TITLE
deps: update to latest google calendar api

### DIFF
--- a/gcal/event.go
+++ b/gcal/event.go
@@ -99,6 +99,7 @@ func (c *client) GetEventsBetweenDates(_ string, start, end time.Time) (events [
 
 	result, err := service.Events.
 		List(defaultCalendarName).
+		EventTypes("default").
 		TimeMin(start.Format(time.RFC3339)).
 		TimeMax(end.Format(time.RFC3339)).
 		OrderBy("startTime").

--- a/gcal/get_default_calendar_view.go
+++ b/gcal/get_default_calendar_view.go
@@ -43,6 +43,7 @@ func (c *client) GetDefaultCalendarView(_ string, start, end time.Time) ([]*remo
 
 	req := service.Events.
 		List(defaultCalendarName).
+		EventTypes("default").
 		TimeMin(start.Format(time.RFC3339)).
 		TimeMax(end.Format(time.RFC3339)).
 		SingleEvents(true).

--- a/gcal/subscription.go
+++ b/gcal/subscription.go
@@ -46,7 +46,7 @@ func (c *client) CreateMySubscription(notificationURL, remoteUserID string) (*re
 		},
 	}
 
-	createSubscriptionRequest := service.Events.Watch(defaultCalendarName, reqBody)
+	createSubscriptionRequest := service.Events.Watch(defaultCalendarName, reqBody).EventTypes("default")
 	googleSubscription, err := createSubscriptionRequest.Do()
 	if err != nil {
 		return nil, errors.Wrap(err, "gcal CreateMySubscription, error creating subscription")


### PR DESCRIPTION
#### Summary
- Update the google calendar dependency to the latest version
- Filtering the events retrieved by type, using `default` to avoid receiving other event types (out of office, focus time, working location)

