### PR TITLE
[MM-73]: Fixed the issue of getting invalid start/end time even though they were set

### DIFF
--- a/webapp/src/components/modals/create_event_form.tsx
+++ b/webapp/src/components/modals/create_event_form.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {Key, useState} from 'react';
+import React, {useState} from 'react';
 import {useSelector, useDispatch} from 'react-redux';
 
 import {Modal} from 'react-bootstrap';

--- a/webapp/src/components/modals/create_event_form.tsx
+++ b/webapp/src/components/modals/create_event_form.tsx
@@ -1,12 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState} from 'react';
+import React, {Key, useState} from 'react';
 import {useSelector, useDispatch} from 'react-redux';
 
 import {Modal} from 'react-bootstrap';
 
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
+
+import ChannelSelector from '../channel_selector';
 
 import {CreateEventPayload} from '@/types/calendar_api_types';
 
@@ -17,7 +19,6 @@ import Loading from '@/components/loading';
 import Setting from '@/components/setting';
 import AttendeeSelector from '@/components/attendee_selector';
 import TimeSelector from '@/components/time_selector';
-import ChannelSelector from '../channel_selector';
 import {capitalizeFirstCharacter} from '@/utils/text';
 import {CreateCalendarEventResponse, createCalendarEvent} from '@/actions';
 import {getTodayString} from '@/utils/datetime';
@@ -221,7 +222,7 @@ const ActualForm = (props: ActualFormProps) => {
                     value={formValues.start_time}
                     endTime={formValues.end_time}
                     date={formValues.date}
-                    onChange={(value) => setFormValue('start_time', value)}
+                    onChange={(name: any, value: string) => setFormValue(name, value)}
                 />
             ),
         },
@@ -233,7 +234,7 @@ const ActualForm = (props: ActualFormProps) => {
                     value={formValues.end_time}
                     startTime={formValues.start_time}
                     date={formValues.date}
-                    onChange={(value) => setFormValue('end_time', value)}
+                    onChange={(name: any, value: string) => setFormValue(name, value)}
                 />
             ),
         },

--- a/webapp/src/components/modals/create_event_form.tsx
+++ b/webapp/src/components/modals/create_event_form.tsx
@@ -222,7 +222,7 @@ const ActualForm = (props: ActualFormProps) => {
                     value={formValues.start_time}
                     endTime={formValues.end_time}
                     date={formValues.date}
-                    onChange={(name: any, value: string) => setFormValue(name, value)}
+                    onChange={(name: keyof CreateEventPayload, value: string) => setFormValue(name, value)}
                 />
             ),
         },
@@ -234,7 +234,7 @@ const ActualForm = (props: ActualFormProps) => {
                     value={formValues.end_time}
                     startTime={formValues.start_time}
                     date={formValues.date}
-                    onChange={(name: any, value: string) => setFormValue(name, value)}
+                    onChange={(name: keyof CreateEventPayload, value: string) => setFormValue(name, value)}
                 />
             ),
         },

--- a/webapp/src/components/time_selector.tsx
+++ b/webapp/src/components/time_selector.tsx
@@ -3,9 +3,9 @@ import {useSelector} from 'react-redux';
 
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
-import {getTodayString} from '@/utils/datetime';
-
 import ReactSelectSetting from './react_select_setting';
+
+import {getTodayString} from '@/utils/datetime';
 
 const minuteStep = 15;
 
@@ -69,11 +69,9 @@ export default function TimeSelector(props: Props) {
         }));
     }, [props.startTime, props.endTime, props.date]);
 
-    let value: Option | undefined | null = options[0];
+    let value: Option | undefined | null;
     if (props.value) {
         value = options.find((option: Option) => option.value === props.value);
-    } else {
-        props.onChange(options[0].value);
     }
 
     const handleChange = (_: string, newValue: string) => {

--- a/webapp/src/components/time_selector.tsx
+++ b/webapp/src/components/time_selector.tsx
@@ -3,9 +3,9 @@ import {useSelector} from 'react-redux';
 
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
-import ReactSelectSetting from './react_select_setting';
-
 import {getTodayString} from '@/utils/datetime';
+
+import ReactSelectSetting from './react_select_setting';
 
 const minuteStep = 15;
 

--- a/webapp/src/components/time_selector.tsx
+++ b/webapp/src/components/time_selector.tsx
@@ -3,15 +3,15 @@ import {useSelector} from 'react-redux';
 
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
-import {getTodayString} from '@/utils/datetime';
-
 import ReactSelectSetting from './react_select_setting';
+
+import {getTodayString} from '@/utils/datetime';
 
 const minuteStep = 15;
 
 type Props = {
     value: string;
-    onChange: (value: string) => void;
+    onChange: (value: string, name: string) => void;
     startTime?: string
     endTime?: string
     date?: string
@@ -75,7 +75,17 @@ export default function TimeSelector(props: Props) {
     }
 
     const handleChange = (_: string, newValue: string) => {
-        props.onChange(newValue);
+        if (props.startTime) {
+            props.onChange('end_time', newValue);
+        } else {
+            props.onChange('start_time', newValue);
+
+            options.forEach((option: Option, i: number) => {
+                if (option.value === newValue && i + 2 < options.length) {
+                    props.onChange('end_time', options[i + 2].value);
+                }
+            });
+        }
     };
 
     return (

--- a/webapp/src/components/time_selector.tsx
+++ b/webapp/src/components/time_selector.tsx
@@ -4,6 +4,7 @@ import {useSelector} from 'react-redux';
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
 import {getTodayString} from '@/utils/datetime';
+import {CreateEventPayload} from '@/types/calendar_api_types';
 
 import ReactSelectSetting from './react_select_setting';
 
@@ -11,7 +12,7 @@ const minuteStep = 15;
 
 type Props = {
     value: string;
-    onChange: (value: string, name: string) => void;
+    onChange: (name: keyof CreateEventPayload, value: string) => void;
     startTime?: string
     endTime?: string
     date?: string

--- a/webapp/src/components/time_selector.tsx
+++ b/webapp/src/components/time_selector.tsx
@@ -72,6 +72,8 @@ export default function TimeSelector(props: Props) {
     let value: Option | undefined | null = options[0];
     if (props.value) {
         value = options.find((option: Option) => option.value === props.value);
+    } else {
+        props.onChange(options[0].value);
     }
 
     const handleChange = (_: string, newValue: string) => {


### PR DESCRIPTION
#### Summary
The start/end time was auto-selected when we opened the modal to create an event but still got the error that they were invalid. So fixed it by removing the autoselected value. 

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-google-calendar/issues/73

#### Ticket Link
1) Run /gcal event create
2) Update the subject and click on submit, the meeting should be created. 