### PR TITLE
fix: revert make dist to its original format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ ifneq ($(HAS_WEBAPP),)
 	mkdir -p dist/$(PLUGIN_ID)/webapp
 	cp -r webapp/dist dist/$(PLUGIN_ID)/webapp/
 endif
-	cd dist && tar -cvzf $(BUNDLE_NAME) -C $(PLUGIN_ID) .
+	cd dist && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
 
 	@echo plugin built at: dist/$(BUNDLE_NAME)
 


### PR DESCRIPTION
### Summary

Fixes the delivery pipeline by bringing back the root folder in the bundle file.
