### PR TITLE
deps: update mscalendar dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mattermost/mattermost-plugin-google-calendar
 go 1.21
 
 require (
-	github.com/mattermost/mattermost-plugin-mscalendar v1.3.0
+	github.com/mattermost/mattermost-plugin-mscalendar v1.2.2-0.20240729101139-b61c35cf3761
 	github.com/mattermost/mattermost/server/public v0.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956 h1:Y1Tu/swM31pVwwb
 github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956/go.mod h1:SRl30Lb7/QoYyohYeVBuqYvvmXSZJxZgiV3Zf6VbxjI=
 github.com/mattermost/logr/v2 v2.0.21 h1:CMHsP+nrbRlEC4g7BwOk1GAnMtHkniFhlSQPXy52be4=
 github.com/mattermost/logr/v2 v2.0.21/go.mod h1:kZkB/zqKL9e+RY5gB3vGpsyenC+TpuiOenjMkvJJbzc=
-github.com/mattermost/mattermost-plugin-mscalendar v1.3.0 h1:5X/J7O956A0uqENvDTrNVgLqWNuBKKXDE5jqlrbOCCY=
-github.com/mattermost/mattermost-plugin-mscalendar v1.3.0/go.mod h1:aIO3y2VNX7VRmI2wvos8MFywGoqFp3zKH6QgyAJMEMQ=
+github.com/mattermost/mattermost-plugin-mscalendar v1.2.2-0.20240729101139-b61c35cf3761 h1:fhmlzfFcSEQoAZAHPQVExkhq3CST2Xrw6rh+xKxOsKY=
+github.com/mattermost/mattermost-plugin-mscalendar v1.2.2-0.20240729101139-b61c35cf3761/go.mod h1:0QMN1lB9ChMWlJzUvC4JPvuAQ882hhwIWwT2kW7GAvo=
 github.com/mattermost/mattermost/server/public v0.1.1 h1:T5UtZ0SB3rZvhiKFUxkPn4fNrEQTXAcmCHVkRct1dpk=
 github.com/mattermost/mattermost/server/public v0.1.1/go.mod h1:WeqCPudYLqk4HjjGvCMJwhtHMVvcNUTHIbrLmLjAD+4=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=


### PR DESCRIPTION
#### Summary

Updates `mscalendar` dependency to latest changes from master to address:

- https://github.com/mattermost/mattermost-plugin-mscalendar/pull/380
- https://github.com/mattermost/mattermost-plugin-mscalendar/pull/377

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

