### PR TITLE
fix: add missing id-token to write to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   plugin-ci:


### PR DESCRIPTION
Summary
Fix CI pipeline by adding permissions for id-token to write

Ticket Link
https://mattermost.atlassian.net/browse/CLD-9264

From: https://github.com/mattermost/mattermost-plugin-starter-template/pull/223
