### PR TITLE
fix: correct 'remidners' to 'reminders' typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Google Calendar plugin for Mattermost.
 - Receive a daily summary at a specific time
 - Receive event reminders 5 minutes before a meeting via direct message
 - Create events directly from a channel, optionally linking them to a channel for reminders
-- Receive event remidners 5 minutes before a meeting via message post
+- Receive event reminders 5 minutes before a meeting via message post
 - Automatically set an user status (away, DND) during meetings
 - View your today or tomorrow's agenda with a slash command
 - Easily configurable settings using an attachment interface


### PR DESCRIPTION
Fixes: mattermost/mattermost-plugin-google-calendar#159


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** The change affects only README text. It does not affect application behavior or public interfaces.

**Regression Risk:** No runtime code or shared dependency changed. Regression risk is negligible.

**QA Recommendation:** Manual QA is not required. Verify the corrected spelling in the README.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->