### PR TITLE
fix: correct typo 'remidners' to 'reminders' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Google Calendar plugin for Mattermost.
 - Receive a daily summary at a specific time
 - Receive event reminders 5 minutes before a meeting via direct message
 - Create events directly from a channel, optionally linking them to a channel for reminders
-- Receive event remidners 5 minutes before a meeting via message post
+- Receive event reminders 5 minutes before a meeting via message post
 - Automatically set an user status (away, DND) during meetings
 - View your today or tomorrow's agenda with a slash command
 - Easily configurable settings using an attachment interface


### PR DESCRIPTION
Fixes a typo in the README where 'reminders' was misspelled as 'remidners'. Closes #159.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** The change only corrects a typo in `README.md`. It does not affect application behavior or public interfaces.

**Regression Risk:** None expected. No code paths, shared dependencies, or critical flows changed.

** QA Recommendation:** Manual QA is not required. Review the updated README text to confirm the spelling.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->