### PR TITLE
fix: correct 'remidners' to 'reminders' typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Google Calendar plugin for Mattermost.
 - Receive a daily summary at a specific time
 - Receive event reminders 5 minutes before a meeting via direct message
 - Create events directly from a channel, optionally linking them to a channel for reminders
-- Receive event remidners 5 minutes before a meeting via message post
+- Receive event reminders 5 minutes before a meeting via message post
 - Automatically set an user status (away, DND) during meetings
 - View your today or tomorrow's agenda with a slash command
 - Easily configurable settings using an attachment interface


### PR DESCRIPTION
## Summary

Fixes a typo in README.md where 'remidners' should be 'reminders':

**Before:** Receive event remidners 5 minutes before a meeting via message post
**After:** Receive event reminders 5 minutes before a meeting via message post

## Issue

Fixes #159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** The change corrects one typo in `README.md`. It does not affect application behavior or shared code.

**Regression Risk:** Very low. The change affects documentation only.

**QA Recommendation:** Manual QA is not required. Review the updated text to confirm the spelling correction.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->